### PR TITLE
[MOBILE-3128] Update gimbal bridge

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,27 +1,23 @@
-===============================
-Version 3.0.0 - July 15, 2019
-===============================
+# Changelog
+
+## Version 3.1.0 - May 31, 2022
+ - Updated Airship Adroid Gimbal Adapter to 7.4.0
+ - Updated Airship iOS Gimbal Adapter to 4.1.0
+
+## Version 3.0.0 - July 15, 2019
  - Updated Gimbal bridge to be compatible with Airship location modules on iOS and Android.
  - Gimbal bridge now requires the cordova >= 9.0.0, cordova-ios >= 5.0.1, cococapods >= 1.7.3
 
-===============================
-Version 2.0.1 - April 5, 2018
-===============================
+## Version 2.0.1 - April 5, 2018
  - Updated Gimbal SDK to 3.1.1
 
-===============================
-Version 2.0.0 - October 7, 2016
-===============================
+## Version 2.0.0 - October 7, 2016
  - Added support for Android
  - Added auto_start flag and start/stop APIs to control when the user is prompted for location permissions
 
-===============================
-Version 1.1.0 - January 7, 2016
-===============================
+## Version 1.1.0 - January 7, 2016
  - Updated README with install instructions
  - Fixed package version
 
-===============================
-Version 1.0.0 - January 7, 2016
-===============================
+## Version 1.0.0 - January 7, 2016
  - Added Gimbal Plugin

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "urbanairship-gimbal-bridge-cordova",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Urban Airship Cordova Gimbal plugin",
   "cordova": {
     "id": "urbanairship-gimbal-bridge-cordova",

--- a/plugin.xml
+++ b/plugin.xml
@@ -45,7 +45,7 @@
                 <source url="https://github.com/CocoaPods/Specs.git"/>
             </config>
             <pods use-frameworks="true">
-                <pod name="Gimbal" spec="2.80.2" />
+                <pod name="AirshipGimbalAdapter" spec="4.1.0" />
             </pods>
         </podspec>
     </platform>

--- a/src/android/GimbalPlugin.java
+++ b/src/android/GimbalPlugin.java
@@ -31,6 +31,8 @@ public class GimbalPlugin extends CordovaPlugin {
         super.initialize(cordova, webView);
         Log.i(TAG, "Initializing Urban Airship Gimbal cordova plugin.");
 
+        GimbalAdapter.shared(cordova.getActivity()).enableGimbalApiKeyManagement(getGimbalKey());
+
         if (GimbalPluginConfig.getInstance(cordova.getActivity()).getAutoStart()) {
             Log.i(TAG, "Auto starting Gimbal Adapter.");
             start(null);
@@ -74,7 +76,7 @@ public class GimbalPlugin extends CordovaPlugin {
     private void start(CallbackContext callbackContext) {
         isStarted = true;
 
-        GimbalAdapter.shared(cordova.getActivity()).startWithPermissionPrompt(getGimbalKey(), new GimbalAdapter.PermissionResultCallback() {
+        GimbalAdapter.shared(cordova.getActivity()).startWithPermissionPrompt(new GimbalAdapter.PermissionResultCallback() {
             @Override
             public void onResult(boolean enabled) {
                 PluginLogger.debug("Gimbal Plugin attempted to start with result: %s", enabled);

--- a/src/android/GimbalPluginConfig.java
+++ b/src/android/GimbalPluginConfig.java
@@ -19,7 +19,7 @@ import java.util.Map;
  */
 public class GimbalPluginConfig {
 
-    private static final String GIMBAL_KEY = "com.urbanairship.gimbal_api_key";
+    private static final String GIMBAL_KEY = "com.urbanairship.android_gimbal_api_key";
     private static final String GIMBAL_AUTO_START = "com.urbanairship.gimbal_auto_start";
     private static final String UA_PREFIX = "com.urbanairship";
 

--- a/src/android/plugin.gradle
+++ b/src/android/plugin.gradle
@@ -7,5 +7,7 @@ allprojects {
 }
 
 dependencies {
-  implementation 'com.urbanairship.android:gimbal-adapter:3.0.0'
+  implementation 'com.urbanairship.android:gimbal-adapter:7.4.0'
+  // Google Play Services
+  implementation "com.google.android.gms:play-services-location:19.0.1"
 }

--- a/src/ios/GimbalAdapter.m
+++ b/src/ios/GimbalAdapter.m
@@ -3,10 +3,8 @@
  */
 
 #import "GimbalAdapter.h"
-#import "UAPush.h"
-#import "UAirship.h"
-#import "UARegionEvent.h"
-#import "UAAnalytics.h"
+
+@import AirshipKit;
 
 #define kSource @"Gimbal"
 
@@ -88,7 +86,7 @@
 - (void)reportPlaceEventToAnalytics:(GMBLPlace *) place boundaryEvent:(UABoundaryEvent) boundaryEvent {
     UARegionEvent *regionEvent = [UARegionEvent regionEventWithRegionID:place.identifier source:kSource boundaryEvent:boundaryEvent];
     
-    [[UAirship shared].analytics addEvent:regionEvent];
+    [UAirship.analytics addEvent:regionEvent];
 }
 
 #pragma mark -

--- a/src/ios/GimbalPlugin.m
+++ b/src/ios/GimbalPlugin.m
@@ -35,7 +35,7 @@ typedef void (^UACordovaExecutionBlock)(NSArray *args, UACordovaCompletionHandle
 @implementation GimbalPlugin
 
 // Config keys
-NSString *const GimbalAPIKey = @"com.urbanairship.gimbal_api_key";
+NSString *const GimbalAPIKey = @"com.urbanairship.ios_gimbal_api_key";
 NSString *const GimbalAutoStartKey = @"com.urbanairship.gimbal_auto_start";
 
 - (void)pluginInitialize {


### PR DESCRIPTION
I updated the gimbal bridge to use our native gimbal adapter.
Also added play services location to android because I noticed Gimbal need it to work.
And then I split the common config key for the Gimbal API key in two (com.urbanairship.**ios_**gimbal_api_key and com.urbanairship.**android_**gimbal_api_key)