### PR TITLE
[GHI-9] update to use AirshipGimbalSDK 4.1.1

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,6 @@
 # Changelog
 
-## Version 3.1.1 - June 14, 2022
+## Version 3.1.1 - July 5, 2022
  - Updated Airship iOS Gimbal Adapter to 4.1.1
 
 ## Version 3.1.0 - June 14, 2022

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 # Changelog
 
+## Version 3.1.1 - June 14, 2022
+ - Updated Airship iOS Gimbal Adapter to 4.1.1
+
 ## Version 3.1.0 - June 14, 2022
  - Updated Airship Adroid Gimbal Adapter to 7.4.0
  - Updated Airship iOS Gimbal Adapter to 4.1.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "urbanairship-gimbal-bridge-cordova",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Urban Airship Cordova Gimbal plugin",
   "cordova": {
     "id": "urbanairship-gimbal-bridge-cordova",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin id="urbanairship-gimbal-bridge-cordova"
-        version="3.0.0"
+        version="3.1.1"
         xmlns="http://www.phonegap.com/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android">
 
@@ -45,7 +45,7 @@
                 <source url="https://github.com/CocoaPods/Specs.git"/>
             </config>
             <pods use-frameworks="true">
-                <pod name="AirshipGimbalAdapter" spec="4.1.0" />
+                <pod name="AirshipGimbalAdapter" spec="4.1.1" />
             </pods>
         </podspec>
     </platform>


### PR DESCRIPTION
Update to use AirshipGimbalSDK 4.1.1 which is using a validated Gimbal SDK version.